### PR TITLE
fix(auth): create user with role from intendedRole cookie; keep existing users’ role intact

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,31 +4,69 @@ import { prisma } from "@/lib/prisma";
 // Para empezar simple: Credentials “dev” (luego agregas Email/Google)
 import Credentials from "next-auth/providers/credentials";
 
+function parseCookie(header: string | null): Record<string, string> {
+  if (!header) return {};
+  return Object.fromEntries(
+    header
+      .split(";")
+      .map((s) => s.trim().split("=", 2))
+      .filter((x) => x.length === 2)
+  );
+}
+
 export const authOptions: NextAuthOptions = {
   adapter: PrismaAdapter(prisma),
   session: { strategy: "jwt" },
+  pages: { signIn: "/auth/start" },
   providers: [
     Credentials({
       name: "Dev Login",
       credentials: { email: { label: "Email", type: "email" } },
-      async authorize(creds) {
+      async authorize(creds, req) {
         if (!creds?.email) return null;
         // Crea/recupera usuario por email y rol por defecto TENANT
-        let user = await prisma.user.findUnique({ where: { email: creds.email } });
-        if (!user) user = await prisma.user.create({ data: { email: creds.email } });
-        return { id: user.id, email: user.email, role: user.role };
+        const existing = await prisma.user.findUnique({ where: { email: creds.email } });
+        if (existing) {
+          // Usuarios existentes mantienen su rol actual (seguridad)
+          return { id: existing.id, email: existing.email ?? undefined, role: existing.role };
+        }
+
+        const cookieHeader = req?.headers?.get("cookie") || "";
+        console.log("cookie header:", cookieHeader);
+        const cookies = parseCookie(cookieHeader);
+        const intendedRole = cookies["intendedRole"] === "LANDLORD" ? "LANDLORD" : "TENANT";
+        console.log("creating user with role:", intendedRole);
+
+        const user = await prisma.user.create({
+          data: { email: creds.email, role: intendedRole },
+        });
+
+        return { id: user.id, email: user.email ?? undefined, role: user.role };
       },
     }),
     // Luego: Email / Google / GitHub ...
   ],
   callbacks: {
     async jwt({ token, user }) {
-      if (user) token.role = (user as any).role ?? "TENANT";
+      if (user && typeof (user as { role?: unknown }).role === "string") {
+        token.role = (user as { role: string }).role;
+      } else if (user) {
+        token.role = "TENANT";
+      }
+      if (typeof token.role !== "string") {
+        token.role = "TENANT";
+      }
       return token;
     },
     async session({ session, token }) {
-      (session as any).role = token.role;
-      (session as any).userId = token.sub;
+      if (session.user) {
+        const role = typeof token.role === "string" ? token.role : "TENANT";
+        session.user = {
+          ...session.user,
+          role,
+          ...(token.sub ? { id: token.sub } : {}),
+        } as typeof session.user & { role: string; id?: string };
+      }
       return session;
     },
   },


### PR DESCRIPTION
## Summary
- parse the intendedRole cookie during credential authorization to set the initial user role and log diagnostics
- keep existing users' roles unchanged on login while propagating role information through JWT and session payloads
- ensure the sign-in page configuration remains pointing to /auth/start

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d1f90fe883288c811eaf920810e0