### PR TITLE
Implement intended role cookie flow for auth

### DIFF
--- a/src/app/auth/set-role/route.ts
+++ b/src/app/auth/set-role/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from "next/server";
+
+type Role = "LANDLORD" | "TENANT";
+
+const TEN_MINUTES = 600;
+const VALID_ROLES = new Set<Role>(["LANDLORD", "TENANT"]);
+
+function isRole(value: string): value is Role {
+  return VALID_ROLES.has(value as Role);
+}
+
+function resolveRole(role: string | null): Role {
+  if (role && isRole(role)) {
+    return role;
+  }
+  return "TENANT";
+}
+
+export async function GET(request: NextRequest) {
+  const role = resolveRole(request.nextUrl.searchParams.get("role"));
+  const prod = process.env.NODE_ENV === "production";
+  const response = NextResponse.redirect(new URL("/auth/start", request.url), {
+    status: 307,
+  });
+
+  response.cookies.set("intendedRole", role, {
+    path: "/",
+    sameSite: "lax",
+    httpOnly: true,
+    secure: prod,
+    maxAge: TEN_MINUTES,
+  });
+
+  return response;
+}

--- a/src/app/auth/start/AuthForm.tsx
+++ b/src/app/auth/start/AuthForm.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { FormEvent, useState } from "react";
+
+export default function AuthForm() {
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const result = await signIn("credentials", { email, callbackUrl: "/" });
+      if (result?.error) {
+        setError(result.error);
+      }
+    } catch {
+      setError("Ocurrió un error. Intenta nuevamente.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-1">
+        <label htmlFor="email" className="text-sm text-slate-300">
+          Correo electrónico
+        </label>
+        <input
+          id="email"
+          type="email"
+          name="email"
+          autoComplete="email"
+          required
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          className="w-full rounded-lg bg-slate-900 border border-slate-700 px-3 py-2 text-white"
+          placeholder="nombre@correo.com"
+        />
+      </div>
+
+      {error ? <p className="text-sm text-red-400">{error}</p> : null}
+
+      <button
+        type="submit"
+        disabled={isSubmitting}
+        className="w-full rounded-lg bg-blue-600 px-4 py-2 font-medium text-white hover:bg-blue-500 disabled:opacity-60"
+      >
+        {isSubmitting ? "Iniciando..." : "Continuar"}
+      </button>
+    </form>
+  );
+}

--- a/src/app/auth/start/page.tsx
+++ b/src/app/auth/start/page.tsx
@@ -1,0 +1,26 @@
+import AuthForm from "./AuthForm";
+import { cookies } from "next/headers";
+
+type Role = "LANDLORD" | "TENANT";
+
+function parseRole(value: string | undefined): Role {
+  return value === "LANDLORD" ? "LANDLORD" : "TENANT";
+}
+
+export default async function AuthStartPage() {
+  const cookieStore = await cookies();
+  const role = parseRole(cookieStore.get("intendedRole")?.value);
+
+  return (
+    <section className="max-w-md mx-auto space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">Accede a tu cuenta</h1>
+        <p className="text-sm text-slate-400">
+          Continuarás como: <span className="font-medium text-white">{role}</span>
+        </p>
+      </header>
+
+      <AuthForm />
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated /auth/set-role route that stores the intended role cookie and redirects to /auth/start
- implement the /auth/start page to read the intended role cookie without mutating it and surface the selected role
- add an AuthForm client component that signs in through the credentials provider with the default callback

## Testing
- npm run lint *(fails: existing lint errors in unrelated tenant pages and API routes)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d7c3be308328910f0b4433766e89